### PR TITLE
Testing and Building with python Version 3.9.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,7 @@ jobs:
         venv32/Scripts/python.exe -m pip install -r requirements.txt
     - name: run build.ps1
       run: ./build.ps1
+    - uses: actions/upload-artifact@v3
+      with:
+        name: upload-artifact
+        path: AlbianWarpClient_*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
     - name: Set up Python x86
       uses: actions/setup-python@v2
       with:
-        python-version: "3.9"
+        python-version: "3.9.12"
         architecture: "x86"
     - name: output python x86 version
-      run: C:\hostedtoolcache\windows\Python\3.9.10\x86\python.exe --version
+      run: C:\hostedtoolcache\windows\Python\3.9.12\x86\python.exe --version
     - name: output python x64 version
-      run: C:\hostedtoolcache\windows\Python\3.9.10\x64\python.exe --version
+      run: C:\hostedtoolcache\windows\Python\3.9.12\x64\python.exe --version
     - name: create venv
       run: |
-        C:\hostedtoolcache\windows\Python\3.9.10\x86\python.exe  -m venv venv32
-        C:\hostedtoolcache\windows\Python\3.9.10\x64\python.exe  -m venv venv
+        C:\hostedtoolcache\windows\Python\3.9.12\x86\python.exe  -m venv venv32
+        C:\hostedtoolcache\windows\Python\3.9.12\x64\python.exe  -m venv venv
     - name: install dependencies
       run: |
         venv/Scripts/python.exe -m pip install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Build & Test
 on:
   pull_request:
     types: [opened, synchronize]
@@ -6,7 +6,7 @@ on:
       - master
       - main
 jobs:
-  test:
+  build:
     runs-on: windows-latest
     steps:
     - name: Checkout
@@ -39,5 +39,5 @@ jobs:
       run: ./build.ps1
     - uses: actions/upload-artifact@v3
       with:
-        name: upload-artifact
+        name: AlbianWarpClients
         path: AlbianWarpClient_*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,21 @@ jobs:
     - name: Set up Python x64
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.9"
         architecture: "x64"
     - name: Set up Python x86
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.9"
         architecture: "x86"
     - name: output python x86 version
-      run: C:\hostedtoolcache\windows\Python\3.10.0\x86\python.exe --version
+      run: C:\hostedtoolcache\windows\Python\3.9.10\x86\python.exe --version
     - name: output python x64 version
-      run: C:\hostedtoolcache\windows\Python\3.10.0\x64\python.exe --version
+      run: C:\hostedtoolcache\windows\Python\3.9.10\x64\python.exe --version
     - name: create venv
       run: |
-        C:\hostedtoolcache\windows\Python\3.10.0\x86\python.exe  -m venv venv32
-        C:\hostedtoolcache\windows\Python\3.10.0\x64\python.exe  -m venv venv
+        C:\hostedtoolcache\windows\Python\3.9.10\x86\python.exe  -m venv venv32
+        C:\hostedtoolcache\windows\Python\3.9.10\x64\python.exe  -m venv venv
     - name: install dependencies
       run: |
         venv/Scripts/python.exe -m pip install -r requirements.txt


### PR DESCRIPTION
This PR changes the Python Version used for building the Client to 3.9.12, as the later Versions are not supported by Windows 7.
Which was requested by a Player on Discord, my reasoning for using 3.9.12 is as follows: 
> I guess, we will stick to 3.9 for now, if no one is objecting, I personally can absolutely NOT recommend running Windows 7, as it is out of Service for a While now, and does not receive any patches (unless you pay a shitload of money for it) BUT! you are not the first person that has this Problem, and, at this point, I would not be surprised to se someone coming around with an Windows XP Setup!
I don't plan to support windows 7 indefinitely!
But as switching to a "slightly" older, but still very much supported version of Python is not to much of an inconvenience to me, we can Build the Client with Version 3.9.10 for now I guess!

Additionally this PR enhanced the Github Action that did the the Build test, to actually upload the resulting built Clients (both 32 and 64 bit) to Github as an artifact.
This takes away the burden for us to maintain windows build systems on our own ^^